### PR TITLE
Improve exam lookup and statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # diemthitsl102425
 
-This repository contains a simple web page for checking entrance exam scores.
-Open `index.html` in a browser, enter a student's SBD, and the results will be
-displayed from the data stored in `data.js`.
+This repository contains a simple web page for looking up entrance exam scores.
+Open `index.html` in a browser and enter a student's SBD or name to see the
+results from `data.js`. Press **Enter** or click the **Tra cứu** button. Use the
+**Xem thống kê** button for detailed statistics including average subject scores,
+pass rate and top/bottom rankings.

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <img src="logo.png" alt="Logo trường THPT Võ Văn Kiệt" class="logo" />
     <h1>Tra cứu điểm tuyển sinh lớp 10</h1>
 
-    <input type="text" id="sbdInput" placeholder="Nhập số báo danh" />
+    <input type="text" id="sbdInput" placeholder="Nhập số báo danh hoặc tên" />
     <button onclick="traCuu()">Tra cứu</button>
 
     
@@ -24,7 +24,7 @@
     <div id="luuY" class="notice-box">
       <h3>📌 Lưu ý:</h3>
       <ul>
-        <li>Vui lòng nhập đúng <strong>số báo danh</strong> (không chứa dấu cách hoặc ký tự đặc biệt).</li>
+        <li>Vui lòng nhập đúng <strong>số báo danh hoặc tên</strong> (không chứa ký tự đặc biệt).</li>
         <li>Kết quả hiển thị chỉ mang tính chất tham khảo.</li>
         <li>Liên hệ Facebook phía dưới nếu bạn gặp sự cố trong quá trình tra cứu.</li>
       </ul>

--- a/script.js
+++ b/script.js
@@ -1,73 +1,150 @@
-@@ -10,25 +10,72 @@ function traCuu() {
-    const tongDiem = parseFloat(hs["Tổng điểm"]);
-    let ketQua = "";
-
-    if (!isNaN(tongDiem)) {
-      ketQua = tongDiem >= 11.25 ? "✅ Đạt" : "❌ Trượt";
-    }
-
-    const ut = isNaN(parseFloat(hs["UT"])) ? "0" : hs["UT"];
-    const kk = isNaN(parseFloat(hs["KK"])) ? "0" : hs["KK"];
-
-    ketQuaDiv.innerHTML = `
-      <table class="result-table">
-        <tr><th>Họ và tên</th><td>${hs["Họ và tên"]}</td></tr>
-        <tr><th>Trường</th><td>${hs["Trường"]}</td></tr>
-        <tr><th>Ngữ văn</th><td>${hs["Ngữ văn"]}</td></tr>
-        <tr><th>Tiếng Anh</th><td>${hs["Tiếng Anh"]}</td></tr>
-        <tr><th>Toán</th><td>${hs["Toán"]}</td></tr>
-        <tr><th>Điểm ưu tiên</th><td>${ut}</td></tr>
-        <tr><th>Điểm khuyến khích</th><td>${kk}</td></tr>
-        <tr><th style="font-size: 1.1em;">Tổng điểm</th><td style="font-size: 1.4em; font-weight: bold;">${hs["Tổng điểm"]}</td></tr>
-        <tr><th>Kết quả</th><td>${ketQua}</td></tr>
-      </table>
-    `;
+function traCuu() {
+  const input = document.getElementById('sbdInput').value.trim();
+  const ketQuaDiv = document.getElementById('ketQua');
+  if (!input) {
+    ketQuaDiv.innerHTML = "<span style='color:red'>Vui lòng nhập số báo danh hoặc tên.</span>";
+    return;
   }
+
+  let hs = data.find(item => item['SBD'] === input);
+  let results = [];
+  if (!hs) {
+    const term = input.toLowerCase();
+    results = data.filter(item => item['Họ và tên'].toLowerCase().includes(term));
+    if (results.length === 1) {
+      hs = results[0];
+    }
+  }
+
+  if (!hs) {
+    if (results.length > 1) {
+      let list = '<p>Tìm thấy nhiều kết quả:</p><ul>';
+      results.forEach(r => {
+        list += `<li>${r['Họ và tên']} - SBD: ${r['SBD']} - Tổng điểm: ${r['Tổng điểm']}</li>`;
+      });
+      list += '</ul>';
+      ketQuaDiv.innerHTML = list;
+    } else {
+      ketQuaDiv.innerHTML = "<span style='color:red'>❌ Không tìm thấy thí sinh.</span>";
+    }
+    return;
+  }
+
+  const tongDiem = parseFloat(hs['Tổng điểm']);
+  let ketQua = '';
+  if (!isNaN(tongDiem)) {
+    ketQua = tongDiem >= 11.25 ? '✅ Đạt' : '❌ Trượt';
+  }
+  const ut = isNaN(parseFloat(hs['UT'])) ? '0' : hs['UT'];
+  const kk = isNaN(parseFloat(hs['KK'])) ? '0' : hs['KK'];
+
+  ketQuaDiv.innerHTML = `
+    <table class="result-table">
+      <tr><th>Họ và tên</th><td>${hs['Họ và tên']}</td></tr>
+      <tr><th>Trường</th><td>${hs['Trường']}</td></tr>
+      <tr><th>Ngữ văn</th><td>${hs['Ngữ văn']}</td></tr>
+      <tr><th>Tiếng Anh</th><td>${hs['Tiếng Anh']}</td></tr>
+      <tr><th>Toán</th><td>${hs['Toán']}</td></tr>
+      <tr><th>Điểm ưu tiên</th><td>${ut}</td></tr>
+      <tr><th>Điểm khuyến khích</th><td>${kk}</td></tr>
+      <tr><th style="font-size: 1.1em;">Tổng điểm</th><td style="font-size: 1.4em; font-weight: bold;">${hs['Tổng điểm']}</td></tr>
+      <tr><th>Kết quả</th><td>${ketQua}</td></tr>
+    </table>
+  `;
 }
 
 function hienThiThongKe() {
-  const thongKeDiv = document.getElementById("thongKe");
+  const thongKeDiv = document.getElementById('thongKe');
   let tongDiemSum = 0;
   let diemCaoNhat = -Infinity;
   let diemThapNhat = Infinity;
   let soThiSinhDat = 0;
+  let sumVan = 0, sumAnh = 0, sumToan = 0;
+  const ranges = {
+    '<10': 0,
+    '10-15': 0,
+    '15-20': 0,
+    '20-25': 0,
+    '>=25': 0,
+  };
   const students = [];
 
   data.forEach(hs => {
-    const diem = parseFloat(hs["Tổng điểm"]);
+    const diem = parseFloat(hs['Tổng điểm']);
+    const van = parseFloat(hs['Ngữ văn']);
+    const anh = parseFloat(hs['Tiếng Anh']);
+    const toan = parseFloat(hs['Toán']);
+    if (!isNaN(van)) sumVan += van;
+    if (!isNaN(anh)) sumAnh += anh;
+    if (!isNaN(toan)) sumToan += toan;
+
     if (!isNaN(diem)) {
       tongDiemSum += diem;
       if (diem > diemCaoNhat) diemCaoNhat = diem;
       if (diem < diemThapNhat) diemThapNhat = diem;
       if (diem >= 11.25) soThiSinhDat++;
-      students.push({ ten: hs["Họ và tên"], sbd: hs["SBD"], diem });
+      if (diem < 10) ranges['<10']++;
+      else if (diem < 15) ranges['10-15']++;
+      else if (diem < 20) ranges['15-20']++;
+      else if (diem < 25) ranges['20-25']++;
+      else ranges['>=25']++;
+      students.push({ ten: hs['Họ và tên'], sbd: hs['SBD'], diem });
     }
   });
 
   if (students.length === 0) {
-    thongKeDiv.innerHTML = "Không có dữ liệu thống kê.";
+    thongKeDiv.innerHTML = 'Không có dữ liệu thống kê.';
     return;
   }
 
   const diemTrungBinh = (tongDiemSum / students.length).toFixed(2);
+  const diemTBVan = (sumVan / students.length).toFixed(2);
+  const diemTBAnh = (sumAnh / students.length).toFixed(2);
+  const diemTBToan = (sumToan / students.length).toFixed(2);
   const tiLeDat = ((soThiSinhDat / students.length) * 100).toFixed(2);
 
   students.sort((a, b) => b.diem - a.diem);
   const top10 = students.slice(0, 10);
-  let top10Html = "<ol>";
+  let top10Html = '<ol>';
   top10.forEach(s => {
     top10Html += `<li>${s.ten} (${s.sbd}) - ${s.diem}</li>`;
   });
-  top10Html += "</ol>";
+  top10Html += '</ol>';
+
+  const bottom10 = [...students].sort((a, b) => a.diem - b.diem).slice(0, 10);
+  let bottom10Html = '<ol>';
+  bottom10.forEach(s => {
+    bottom10Html += `<li>${s.ten} (${s.sbd}) - ${s.diem}</li>`;
+  });
+  bottom10Html += '</ol>';
+
+  let rangeHtml = '<ul>';
+  for (const [r, c] of Object.entries(ranges)) {
+    rangeHtml += `<li>${r}: ${c}</li>`;
+  }
+  rangeHtml += '</ul>';
 
   thongKeDiv.innerHTML = `
     <h3>Thống kê</h3>
     <p>Số lượng thí sinh: ${students.length}</p>
     <p>Điểm trung bình: ${diemTrungBinh}</p>
+    <p>Điểm TB Ngữ văn: ${diemTBVan}</p>
+    <p>Điểm TB Tiếng Anh: ${diemTBAnh}</p>
+    <p>Điểm TB Toán: ${diemTBToan}</p>
     <p>Điểm cao nhất: ${diemCaoNhat}</p>
     <p>Điểm thấp nhất: ${diemThapNhat}</p>
     <p>Số thí sinh đạt: ${soThiSinhDat} (${tiLeDat}%)</p>
     <h4>Top 10 thí sinh có điểm cao nhất:</h4>
     ${top10Html}
+    <h4>Top 10 thí sinh có điểm thấp nhất:</h4>
+    ${bottom10Html}
+    <h4>Phân bố điểm:</h4>
+    ${rangeHtml}
   `;
 }
+
+document.getElementById('sbdInput').addEventListener('keypress', e => {
+  if (e.key === 'Enter') {
+    traCuu();
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,111 @@
-@@ -109,25 +109,39 @@ footer a {
+/* Reset & nền */
+body {
+  font-family: "Segoe UI", sans-serif;
+  background-color: #f4f7fb;
+  margin: 0;
+  padding: 0;
+}
+
+/* Giao diện chính */
+.container {
+  max-width: 500px;
+  margin: 50px auto;
+  background-color: #ffffff;
+  padding: 30px 20px;
+  border-radius: 12px;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}
+
+/* Logo */
+.logo {
+  width: 100px;
+  margin-bottom: 20px;
+}
+
+/* Tiêu đề */
+h1 {
+  font-size: 24px;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+/* Ô nhập và nút */
+input[type="text"] {
+  width: 80%;
+  padding: 12px;
+  font-size: 16px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+}
+
+button {
+  padding: 10px 24px;
+  font-size: 16px;
+  background-color: #007bff;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+/* Kết quả */
+.result {
+  margin-top: 25px;
+  padding: 15px;
+  border-radius: 8px;
+  background-color: #f1f1f1;
+  font-size: 15px;
+  line-height: 1.5;
+  min-height: 40px;
+}
+
+/* Thông báo lưu ý */
+.notice-box {
+  margin-top: 20px;
+  padding: 15px 20px;
+  background-color: #fffbea;
+  color: #856404;
+  border-left: 5px solid #ffc107;
+  border-radius: 8px;
+  text-align: left;
+  font-size: 14px;
+  box-shadow: 0 1px 5px rgba(0,0,0,0.05);
+}
+
+.notice-box .pin {
+  font-size: 18px;
+  color: #e83e8c;
+  margin-right: 6px;
+}
+
+.notice-box ul {
+  padding-left: 20px;
+  margin: 10px 0 0 0;
+}
+
+.notice-box li {
+  margin-bottom: 6px;
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  font-size: 14px;
+  background-color: #e9ecef;
+  padding: 15px;
+  margin-top: 50px;
+  color: #444;
+}
+
+footer a {
   color: #007bff;
   text-decoration: none;
 }
@@ -23,17 +130,4 @@ footer a:hover {
 }
 .result-table td {
   background-color: #fff;
-}
-
-.stats {
-  margin-top: 30px;
-  padding: 15px;
-  border-radius: 8px;
-  background-color: #f1f1f1;
-  text-align: left;
-  font-size: 15px;
-  line-height: 1.5;
-}
-.stats ol {
-  padding-left: 20px;
 }


### PR DESCRIPTION
## Summary
- allow searching by SBD or name and trigger search on Enter key
- restore complete CSS
- add detailed statistics (avg subject scores, pass rate, top/bottom lists, score distribution)
- update instructions in README and UI texts

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6848ee562aec8323ac878079df844a85